### PR TITLE
Feat input valid

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-api-common",
       author="Kevin Broadwater, Nicholas Willhite",
       author_email="willnx84@gmail.com",
-      version='2018.05.30',
+      version='2018.06.03',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_api_common/__init__.py
+++ b/vlab_api_common/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: UTF-8 -*-
-from .flask_common import BaseView, describe
+from .flask_common import BaseView, describe, validate_input
 from .std_logger import get_logger
 from .http_auth import deny, requires


### PR DESCRIPTION
Ensuring the user supplied a valid HTTP body per the defined schema turns out to be really repetitive 😅 
So I whipped up this decorator to make life easier, here's an example of _how do_:

```
class MyView(BaseView):

    @requires()
    @validate_input(some_schema)
    def post(*args, **kwargs):
        return 'woot', 200
```

**NOTE** The HTTP body is pulled right off the `request`, so the decorator will pass the body to the function via the keyword `body`