### PR TITLE
Use urljoin instead of path.join

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-api-common",
       author="Kevin Broadwater, Nicholas Willhite",
       author_email="willnx84@gmail.com",
-      version='2018.06.03',
+      version='2018.06.04',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_api_common/constants.py
+++ b/vlab_api_common/constants.py
@@ -4,7 +4,8 @@ This module contains run time variables that do not change during run time. The
 idea is to only ever build one source of truth (be it a binary, or package), and
 execute that same built thing regardless of the runtime environment.
 """
-from os import environ, path
+from os import environ
+from urllib.parse import urljoin
 from collections import namedtuple, OrderedDict
 
 import requests
@@ -28,7 +29,7 @@ def get_public_key():
     a new concept to the testing framework.
     """
     if environ.get('PRODUCTION', False) == 'true':
-        resp = requests.get(path.join(VLAB_URL,'/api/1/auth/key'))
+        resp = requests.get(urljoin(VLAB_URL,'/api/1/auth/key'))
         resp.raise_for_status()
         data = resp.json()
         return data['content']['key']


### PR DESCRIPTION
I am seeing really weird behavior when using path.join for urls on python 3.6.  

```
In [11]: path.join('http://localhost:5000', 'api')
Out[11]: 'http://localhost:5000/api'

In [12]: path.join('http://localhost:5000', '/api')
Out[12]: '/api'
```

Using urljoin doesn't present this and feels a little more appropriate for what this is creating. 