### PR TITLE
Bug defaults to none

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-api-common",
       author="Kevin Broadwater, Nicholas Willhite",
       author_email="willnx84@gmail.com",
-      version='2018.06.04',
+      version='2018.07.02',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -141,22 +141,7 @@ class TestGetTokenFromHeader(unittest.TestCase):
         """The function `get_token_from_header` raises ExpiredSignatureError
         when the token is expired.
         """
-        claims = {'exp' : time.time() - 10000,
-                  'iss' : http_auth.const.AUTH_TOKEN_ISSUER
-                 }
-        token = jwt.encode(claims,
-                           http_auth.const.AUTH_TOKEN_PUB_KEY,
-                           algorithm=http_auth.const.AUTH_TOKEN_ALGORITHM)
-        fake_request.headers.get.return_value = token
-
-        self.assertRaises(jwt.ExpiredSignatureError, http_auth.get_token_from_header)
-
-    @patch.object(http_auth, 'request')
-    def test_get_token_from_header_doh(self, fake_request):
-        """The function `get_token_from_header` raises ExpiredSignatureError
-        when no token is supplied in the HTTP header.
-        """
-        fake_request.headers.get.side_effect = [AttributeError('testing')]
+        fake_request.headers.get.return_value = None
 
         self.assertRaises(jwt.ExpiredSignatureError, http_auth.get_token_from_header)
 

--- a/vlab_api_common/http_auth.py
+++ b/vlab_api_common/http_auth.py
@@ -123,10 +123,8 @@ def get_token_from_header():
 
     :Raises: ExpiredSignatureError
     """
-    try:
-        serialized_token = request.headers.get('X-Auth')
-    except AttributeError:
-        # no token in header
+    serialized_token = request.headers.get('X-Auth', default=None)
+    if serialized_token is None:
         raise ExpiredSignatureError('No auth token in HTTP header')
     else:
         return decode(serialized_token,


### PR DESCRIPTION
Looks like the dictionary that holds the request headers changed in flask/werkzeug. 

Instead of raising `AttributeError` (like a normal dict in Python) when asking for a key that does not exist, `None` is returned instead. Not sure why in the hell they did this, but it did break every vLab end point that requires a token because we'd sciently pass `None` to `jwt.decode`. Instead of giving a useful _"go get a token"_ response, the server would barf:

```
link-api_1  | 172.18.0.1 - - [02/Jul/2018 16:30:31] "GET /api/1/link?describe HTTP/1.1" 500 -
link-api_1  | Traceback (most recent call last):
link-api_1  |   File "/usr/lib/python3.6/site-packages/flask/app.py", line 2309, in __call__
link-api_1  |     return self.wsgi_app(environ, start_response)
link-api_1  |   File "/usr/lib/python3.6/site-packages/flask/app.py", line 2295, in wsgi_app
link-api_1  |     response = self.handle_exception(e)
link-api_1  |   File "/usr/lib/python3.6/site-packages/flask/app.py", line 1741, in handle_exception
link-api_1  |     reraise(exc_type, exc_value, tb)
link-api_1  |   File "/usr/lib/python3.6/site-packages/flask/_compat.py", line 35, in reraise
link-api_1  |     raise value
link-api_1  |   File "/usr/lib/python3.6/site-packages/flask/app.py", line 2292, in wsgi_app
link-api_1  |     response = self.full_dispatch_request()
link-api_1  |   File "/usr/lib/python3.6/site-packages/flask/app.py", line 1815, in full_dispatch_request
link-api_1  |     rv = self.handle_user_exception(e)
link-api_1  |   File "/usr/lib/python3.6/site-packages/flask/app.py", line 1718, in handle_user_exception
link-api_1  |     reraise(exc_type, exc_value, tb)
link-api_1  |   File "/usr/lib/python3.6/site-packages/flask/_compat.py", line 35, in reraise
link-api_1  |     raise value
link-api_1  |   File "/usr/lib/python3.6/site-packages/flask/app.py", line 1813, in full_dispatch_request
link-api_1  |     rv = self.dispatch_request()
link-api_1  |   File "/usr/lib/python3.6/site-packages/flask/app.py", line 1799, in dispatch_request
link-api_1  |     return self.view_functions[rule.endpoint](**req.view_args)
link-api_1  |   File "/usr/lib/python3.6/site-packages/flask_classy.py", line 200, in proxy
link-api_1  |     response = view(**request.view_args)
link-api_1  |   File "/usr/lib/python3.6/site-packages/vlab_api_common/http_auth.py", line 33, in inner
link-api_1  |     fresh_token = get_token_from_header()
link-api_1  |   File "/usr/lib/python3.6/site-packages/vlab_api_common/http_auth.py", line 136, in get_token_from_header
link-api_1  |     leeway=10) # 10 Seconds fuzzy window for clock skewing
link-api_1  |   File "/usr/lib/python3.6/site-packages/jwt/api_jwt.py", line 85, in decode
link-api_1  |     payload, _, _, _ = self._load(jwt)
link-api_1  |   File "/usr/lib/python3.6/site-packages/jwt/api_jws.py", line 178, in _load
link-api_1  |     binary_type))
link-api_1  | jwt.exceptions.DecodeError: Invalid token type. Token must be a <class 'bytes'>

```