### PR TITLE
requires and deny decoratores send token via header now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-api-common",
       author="Kevin Broadwater, Nicholas Willhite",
       author_email="willnx84@gmail.com",
-      version='2018.07.02',
+      version='2018.08.02',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_api_common/http_auth.py
+++ b/vlab_api_common/http_auth.py
@@ -40,7 +40,7 @@ def requires(username=None, memberOf=None, version=const.AUTH_TOKEN_VERSION, ver
                     return resp
 
             if verify is True and kwargs.get('verified', False) is False:
-                resp = requests.get('{}{}'.format(const.VLAB_URL, '/api/1/auth'), params={'token': kwargs['token']})
+                resp = requests.get('{}{}'.format(const.VLAB_URL, '/api/1/auth'), headers={'X-Auth': kwargs['token']})
                 if not resp.ok:
                     return resp.content, resp.status
                 else:
@@ -76,7 +76,7 @@ def deny(username=None, memberOf=None, version=None, verify=True):
                     return resp
 
             if verify is True and kwargs.get('verified', False) is False:
-                resp = requests.get('{}{}'.format(const.VLAB_URL, '/api/1/auth'), params={'token': kwargs['token']})
+                resp = requests.get('{}{}'.format(const.VLAB_URL, '/api/1/auth'), headers={'X-Auth': kwargs['token']})
                 if not resp.ok:
                     return resp.content, resp.status
                 else:


### PR DESCRIPTION
Update to accommodate change in the auth server via https://github.com/willnx/vlab_auth_service/pull/8