### PR TITLE
Update bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install: uninstall build
 	pip install -U dist/*.whl
 
 uninstall:
-	-python uninstall -y vlab-api-common
+	-pip uninstall -y vlab-api-common
 
 test: uninstall install
 	cd tests && nosetests -v --with-coverage --cover-package=vlab_api_common

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-api-common",
       author="Kevin Broadwater, Nicholas Willhite",
       author_email="willnx84@gmail.com",
-      version='2020.11.06',
+      version='2020.12.29',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_api_common/http_auth.py
+++ b/vlab_api_common/http_auth.py
@@ -159,6 +159,8 @@ def generate_test_token(username='pat', memberOf=None, version=1, expires_at=999
     """Creates a test token that works with the `requires` and `deny` decorators
     for unit testing.
 
+    :Returns: Bytes
+
     :param username: The username of your test subject, muhahahaha!
     :type username: String
 
@@ -184,12 +186,14 @@ def generate_test_token(username='pat', memberOf=None, version=1, expires_at=999
               'version' : version,
               'memberOf' : memberOf,
              }
-    return encode(claims, const.AUTH_TOKEN_PUB_KEY, algorithm=const.AUTH_TOKEN_ALGORITHM)
+    return encode(claims, const.AUTH_TOKEN_PUB_KEY, algorithm=const.AUTH_TOKEN_ALGORITHM).encode()
 
 
 def generate_v2_test_token(username='pat', version=2, expires_at=9999999999999, issued_at=0, client_ip='127.0.0.1'):
     """Creates a version 2 test token that works with the `requires` and `deny` decorators
     for unit testing.
+
+    :Returns: Bytes
 
     :param username: The username of your test subject
     :type username: String
@@ -214,4 +218,4 @@ def generate_v2_test_token(username='pat', version=2, expires_at=9999999999999, 
               'client_ip' : client_ip,
               'email' : "{}@vlab.local".format(username)
              }
-    return encode(claims, const.AUTH_TOKEN_PUB_KEY, algorithm=const.AUTH_TOKEN_ALGORITHM)
+    return encode(claims, const.AUTH_TOKEN_PUB_KEY, algorithm=const.AUTH_TOKEN_ALGORITHM).encode()


### PR DESCRIPTION
PyJWT 2.0.0 returns a string instead of bytes when creating a JSON Web Token:
https://github.com/jpadilla/pyjwt/releases/tag/2.0.0

Having bytes is handy for testing, because the test framework takes bytes instead of a string. Simple fix - cast the string to bytes!